### PR TITLE
fix(arc-saas): On Selection of "Basic" tier, the size field is expected to be set to an empty string or a default value

### DIFF
--- a/projects/saas-ui/src/app/main/components/add-plan/add-plan.component.ts
+++ b/projects/saas-ui/src/app/main/components/add-plan/add-plan.component.ts
@@ -103,6 +103,9 @@ export class AddPlanComponent implements OnInit {
     const domainData = this.addPlanForm.value;
     domainData.price = parseFloat(domainData.price);
     domainData.tier = String(domainData.tier);
+    if (domainData.tier === 'BASIC') {
+      domainData.size = '';
+    }
     const featuresGroup = this.addPlanForm.get('features') as FormGroup;
     const selectedFeatures = Object.keys(featuresGroup.controls)
       .filter(


### PR DESCRIPTION

## Description
When selecting the "Basic" tier, the size field is expected to be set to an empty string or a default value. 

Fixes #97 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Intermediate change (work in progress)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] Performed a self-review of my own code
- [ ] npm test passes on your machine
- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the style guide
- [ ] API Documentation in code was updated
- [ ] Any dependent changes have been merged and published in downstream modules
